### PR TITLE
fixes issue #5 removing autscrolling on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,13 +1,13 @@
 (function() {
 
-function setUpFullpage(screenSize) {
+function setUpFullpage() {
   $('#fullpage').fullpage({
     anchors: ['home-page', 'history', 'lokole', 'help-us', 'news', 'contact'],
     menu: '#navbar-menu',
     paddingTop: '80px',
     paddingBottom: '60px',
-    responsiveHeight: screenSize.height,
-    responsiveWidth: screenSize.width,
+    responsiveHeight: 800,
+    responsiveWidth: 800,
     afterRender: function() {
       $('#website-content').removeClass('hidden');
     }
@@ -26,12 +26,7 @@ function assignModalTitleAndContent($clicked) {
 
 $(document).ready(function() {
 
-  var screenSize = {
-    height: $(window).height(),
-    width: $(window).width()
-  };
-
-  setUpFullpage(screenSize);
+  setUpFullpage();
 
   $('.navbar-nav li a').click(function() {
     $('.navbar-collapse').collapse('hide');


### PR DESCRIPTION
This PR fixes issue #5 by removing the fullpage autscroll when the screen's height or width is smaller than 800px.

I fixed it by setting `responsiveHeight` and `responsiveWidth` options to `800` as described in the [fullpage documentation](https://github.com/alvarotrigo/fullPage.js#fullpagejs).

Here they also provide a [demo](https://alvarotrigo.com/fullPage/examples/responsive.html).