### PR TITLE
Fix background image on Edge

### DIFF
--- a/style.css
+++ b/style.css
@@ -158,7 +158,6 @@ a.no-style {
   background-image: url('static/home-page-bg.jpg');
   background-repeat: no-repeat;
   background-position: center center;
-  background-attachment: fixed;
   background-size: cover;
 }
 

--- a/style.css
+++ b/style.css
@@ -155,7 +155,10 @@ a.no-style {
 /* #home-page */
 
 #home {
-  background: url('static/home-page-bg.jpg') no-repeat center center fixed;
+  background-image: url('static/home-page-bg.jpg');
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-attachment: fixed;
   background-size: cover;
 }
 


### PR DESCRIPTION
Removing the `background-attachment: fixed` property seems to fix https://github.com/ascoderu/ascoderu.github.io/issues/9

Edge:

![image](https://user-images.githubusercontent.com/1086421/34910616-ecdad5c2-f886-11e7-80ba-0a49446e6736.png)

Chrome:

![image](https://user-images.githubusercontent.com/1086421/34910619-ff69006a-f886-11e7-80bc-c9158efe6a57.png)

Firefox:

![image](https://user-images.githubusercontent.com/1086421/34910620-0a67e3b4-f887-11e7-96c1-de56d7be98c7.png)
